### PR TITLE
hotfix: create new kubernetes client per request

### DIFF
--- a/src/main/java/cd/go/contrib/secrets/kubernetes/KubernetesClientFactory.java
+++ b/src/main/java/cd/go/contrib/secrets/kubernetes/KubernetesClientFactory.java
@@ -46,7 +46,7 @@ public class KubernetesClientFactory {
         return this.client;
     }
 
-    private KubernetesClient createClientFor(SecretConfig secretConfig) {
+    public static KubernetesClient createClientFor(SecretConfig secretConfig) {
         final ConfigBuilder configBuilder = new ConfigBuilder()
                 .withOauthToken(secretConfig.getSecurityToken())
                 .withMasterUrl(secretConfig.getClusterUrl())

--- a/src/main/java/cd/go/contrib/secrets/kubernetes/SecretConfigLookupExecutor.java
+++ b/src/main/java/cd/go/contrib/secrets/kubernetes/SecretConfigLookupExecutor.java
@@ -22,7 +22,7 @@ public class SecretConfigLookupExecutor extends LookupExecutor<SecretConfigReque
     @Override
     protected GoPluginApiResponse execute(SecretConfigRequest request) {
         SecretConfig secretConfig = request.getConfiguration();
-        KubernetesClient client = KubernetesClientFactory.instance().client(secretConfig);
+        KubernetesClient client = KubernetesClientFactory.createClientFor(secretConfig);
         try {
             List<String> secretIds = request.getKeys();
             if (secretIds == null || secretIds.isEmpty()) {


### PR DESCRIPTION
if more than a job is started simultaneously with the same secretConfig, the client will be reused, but the first job that succeeds will close it

this is just a hotfix for now; hope to eventually upstream a more proper fix